### PR TITLE
Changed font color for Canvas.

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -1798,3 +1798,7 @@ html.appearance-asphalt body {
   color: #FFFFFF;
   border-color: #383838;
 }
+
+.bgagame-canvas .player-board, .bgagame-canvas .canvas-painting-ribbons{
+  color:#000;
+}


### PR DESCRIPTION
Modified font color in the painting tool and side bar to be legible. The background is very light with this theme applied, and the font defaults to white, so it was impossible to read. This change makes the panting tool and side bar black, and keeps the same color in the main window, as that was fine already.